### PR TITLE
Add auto-reconnect = true if proxy (match no-proxy behaviour)

### DIFF
--- a/src/main/java/com/ullink/slack/review/Connector.java
+++ b/src/main/java/com/ullink/slack/review/Connector.java
@@ -17,9 +17,9 @@ import com.ullink.slack.simpleslackapi.impl.SlackSessionFactory;
 
 public class Connector
 {
-    private static final String             DEFAULT_PROPERTIES_FILE = "slack4gerrit.properties";
-    public static Injector                  injector                = null;
-    private static ScheduledExecutorService scheduledExecutor       = Executors.newScheduledThreadPool(1);
+    private static final String DEFAULT_PROPERTIES_FILE = "slack4gerrit.properties";
+    public static Injector injector = null;
+    private static ScheduledExecutorService scheduledExecutor = Executors.newScheduledThreadPool(1);
 
     public static void main(String[] args) throws Exception
     {
@@ -39,7 +39,7 @@ public class Connector
         {
             String proxyURL = parameters.getProperty(Constants.PROXY_HOST);
             int proxyPort = Integer.parseInt(parameters.getProperty(Constants.PROXY_PORT, "80"));
-            session = SlackSessionFactory.getSlackSessionBuilder(parameters.getProperty(Constants.BOT_TOKEN)).withProxy(Proxy.Type.HTTP, proxyURL, proxyPort).build();
+            session = SlackSessionFactory.getSlackSessionBuilder(parameters.getProperty(Constants.BOT_TOKEN)).withProxy(Proxy.Type.HTTP, proxyURL, proxyPort).withAutoreconnectOnDisconnection(true).build();
         }
         else
         {


### PR DESCRIPTION
If no proxy parameter is provided in the config, the session is created with auto-reconnect = true
If a proxy parameter is provided in the config, the session is created with auto-reconnect = false
As we are using a proxy on ul-slack-bot-ctb, whenever the bot is disconnected (which happens 2-3 times a week), it stays up but disconnected and does not do anything afterwards (idle). We need to restart it manually in such cases.
=> this commit is to harmonize both without-proxy and with-proxy cases, and make sure the bot tries to reconnect upon disconnection (instead of staying idle)